### PR TITLE
#141 add: hideContributeComponent option to settings

### DIFF
--- a/examples/default-template/blog.settings.js
+++ b/examples/default-template/blog.settings.js
@@ -24,3 +24,5 @@ export const footerLinks = {
     },
   ],
 }
+
+export const hideContributeComponent = true

--- a/examples/default-template/nuxt.config.js
+++ b/examples/default-template/nuxt.config.js
@@ -1,5 +1,5 @@
 import theme from '@jsilva-pt/nuxt-content-theme-blog'
-import { footerLinks } from './blog.settings'
+import { footerLinks, hideContributeComponent } from './blog.settings'
 
 const baseUrl = 'https://default-template.vercel.app'
 
@@ -14,6 +14,7 @@ const publicRuntimeConfig = {
   githubMainBranch: 'master',
 
   footerLinks,
+  hideContributeComponent,
 }
 
 export default theme({

--- a/packages/nuxt-content-theme-blog/pages/_slug.vue
+++ b/packages/nuxt-content-theme-blog/pages/_slug.vue
@@ -4,7 +4,7 @@
       <BackToList />
       <BlogpostItem :post="post" />
       <BlogpostNavigationLinks :prev="prev" :next="next" />
-      <AppContribute :doc-link="docLink" />
+      <AppContribute v-if="!$config.hideContributeComponent" :doc-link="docLink" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
It's just for example. By the way, I think we should use a common variable for settings object because it's not comfortable to import all of them each time when you will add them. `settings from` instead of `{ footerLinks, xxx, .... } from`